### PR TITLE
Require file automatically on gem load

### DIFF
--- a/lib/rspec-parameterized-context.rb
+++ b/lib/rspec-parameterized-context.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'rspec_parameterized_context'


### PR DESCRIPTION
Bundler can load path automatically if a file with the same name as gem exists.

```ruby
gem 'rspec-parameterized-context' #=> Load "lib/rspec-parameterized-context"
```