### PR TITLE
Cosmetic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ Add this line to your application's Gemfile:
 gem 'rspec-parameterized-context'
 ```
 
-Then add this line to files under `spec/support/`
+Then add this lines to files under `spec/support/`
 
 ```ruby
-require 'rspec_parameterized_context'
-
 RSpec.configure do |config|
   config.extend RSpecParameterizedContext
 end
@@ -22,7 +20,7 @@ end
 
 ## Usage
 
-### syntax
+### Syntax
 
 Provide interfaces like `RSpec::Parameterized`.
 
@@ -48,7 +46,7 @@ describe "Addition" do
 end
 ```
 
-### feature
+### Feature
 
 rspec-parameterized-context supports to evaluate block that given where method in transaction.
 


### PR DESCRIPTION
Remove `require 'rspec_parameterized_context'` because of enabled automatically loading by https://github.com/alpaca-tc/rspec-parameterized-context/commit/7c8eacb1bfc8dfbc7358769b0ab788d5ab0b4d97