### PR TITLE
Make focus_index parameter for running specific context

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ end
 
 ### Feature
 
-rspec-parameterized-context supports to evaluate block that given where method in transaction.
+- rspec-parameterized-context supports to evaluate block that given where method in transaction.
 
 ```ruby
 # Assume today is 2020/9/9
@@ -76,6 +76,27 @@ describe 'Evaluting block that given to where in transaction' do
 end
 ```
 
+- You can run specific context by focus_index parameter
+
+```ruby
+describe "Addition" do
+  parameterized do
+    where(:a, :b, :answer, size: 3, focus_index: 1) do
+      [
+        [1 , 2 , 3],
+        [5 , 8 , 13], # will run only this context
+        [0 , 0 , 0]
+      ]
+    end
+
+    with_them do
+      it do
+        expect(a + b).to eq answer
+      end
+    end
+  end
+end
+```
 
 ## Contributing
 

--- a/lib/rspec_parameterized_context.rb
+++ b/lib/rspec_parameterized_context.rb
@@ -14,6 +14,7 @@ module RSpecParameterizedContext
     def where(*names, size:, focus_index: nil, &block)
       @where_names = names
       @where_size = size
+      @where_focus_index = focus_index
       @where_block = block
     end
 
@@ -28,9 +29,12 @@ module RSpecParameterizedContext
       where_block = @where_block
       where_names = @where_names
       where_size = @where_size
+      where_focus_index = @where_focus_index
       with_them_block = @with_them_block
 
       where_size.times do |index|
+        next if where_focus_index && index != where_focus_index
+
         @rspec_context.context("parameterized phase ##{index}") do
           let(:_parameters) do
             instance_exec(&where_block)


### PR DESCRIPTION
# What I want

Run specific context that define in block given to where method. Usually, I comment out except the context that I want run. I'll be happy to find a way to do something other than comment out.

# Suggest

Why don't we support a parameter that allows us to run specific context??

```ruby
describe "Addition" do
  parameterized do
    where(:a, :b, :answer, size: 3, focus_index: 1) do
      [
        [1 , 2 , 3],
        [5 , 8 , 13], # will run only this context
        [0 , 0 , 0]
      ]
    end
    with_them do
      it do
        expect(a + b).to eq answer
      end
    end
  end
end
```
